### PR TITLE
Enable schedule for menu scraper workflow

### DIFF
--- a/.github/workflows/daily_menu_scrape.yml
+++ b/.github/workflows/daily_menu_scrape.yml
@@ -1,8 +1,8 @@
 name: Daily Menu Scraper
 
 on:
-  # schedule:
-  #   - cron: '5 7 * * 1-5'
+  schedule:
+    - cron: '5 7 * * 1-5'
   workflow_dispatch:  # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
## Summary
- re-enable the cron schedule in `daily_menu_scrape.yml`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840643645908324b5ba226f2a542e3f