### PR TITLE
Add button to Google Chat message

### DIFF
--- a/src/menu_scraper.py
+++ b/src/menu_scraper.py
@@ -121,16 +121,30 @@ class MenuScraper:
                         "title": f"🍽️ Обедното меню за днес ({datetime.now().strftime('%d-%m-%Y')})"
                     },
                     "sections": [{
-                        "widgets": [{
-                            "image": {
-                                "imageUrl": image_url,
-                                "onClick": {
-                                    "openLink": {
-                                        "url": image_url
+                        "widgets": [
+                            {
+                                "image": {
+                                    "imageUrl": image_url,
+                                    "onClick": {
+                                        "openLink": {
+                                            "url": image_url
+                                        }
                                     }
                                 }
+                            },
+                            {
+                                "buttons": [{
+                                    "textButton": {
+                                        "text": "Виж във Facebook",
+                                        "onClick": {
+                                            "openLink": {
+                                                "url": self.fb_page_url
+                                            }
+                                        }
+                                    }
+                                }]
                             }
-                        }]
+                        ]
                     }]
                 }]
             }


### PR DESCRIPTION
## Summary
- include Facebook page link button in the Google Chat card

## Testing
- `python3 -m py_compile src/menu_scraper.py`
- `python3 -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68406451bc88832489ae26db7b958ca5